### PR TITLE
Fixing the problem with having "div" elements as children of "ul"

### DIFF
--- a/src/Pickles/Pickles.Test/Formatters/HtmlTableOfContentsFormatterTests.cs
+++ b/src/Pickles/Pickles.Test/Formatters/HtmlTableOfContentsFormatterTests.cs
@@ -70,5 +70,16 @@ namespace Pickles.Test.Formatters
             Assert.AreEqual("SubLevelOne/LevelOneSublevelOne.html", anchorInLI2.Attribute("href").Value);
             Assert.AreEqual("Addition", anchorInLI2.Value);
         }
+
+        [Test]
+        public void Ul_Element_Must_Contain_Li_Children_Only()
+        {
+            var childrenOfUl = _toc.Elements().First().Elements();
+
+            int numberOfChildren = childrenOfUl.Count();
+            int numberOfLiChildren = childrenOfUl.Count(e => e.Name.LocalName == "li");
+
+            Assert.AreEqual(numberOfChildren, numberOfLiChildren);
+        }
     }
 }

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableOfContentsFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableOfContentsFormatter.cs
@@ -40,11 +40,11 @@ namespace Pickles.DocumentationBuilders.HTML
             {
                 if (childNode.Data.IsContent)
                 {
-                    ul.Add(new XElement(xmlns + "div",
-                               new XAttribute("class", "file"),
-                               new XElement(xmlns + "li",
-                                   new XElement(xmlns + "a",
-                                       new XAttribute("href", childNode.Data.GetRelativeUriTo(file)), childNode.Data.Name))));
+                    ul.Add(
+                        new XElement(
+                            xmlns + "li",
+                            new XAttribute("class", "file"),
+                            new XElement(xmlns + "a", new XAttribute("href", childNode.Data.GetRelativeUriTo(file)), childNode.Data.Name)));
                 }
                 else
                 {


### PR DESCRIPTION
The Html specification says that "ul" can have only "li" children.  Pickles generates "div" children, however.

My first idea was to make the "li" children contain the "div", but then it turned out that the CSS stylesheet does not need the "div" at all: the pages render the same if the "div" element is absent.

So I wrote a unit test that checks whether all children of "ul" are of type "li", and then I fixed the production code.

Dirk
