### PR TITLE
Fixing the problem with "li" elements having an "id" attribute that starts with a number

### DIFF
--- a/src/Pickles/Pickles.Test/Formatters/HtmlScenarioFormatterTests.cs
+++ b/src/Pickles/Pickles.Test/Formatters/HtmlScenarioFormatterTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
+using NUnit.Framework;
+using Ninject;
+using Pickles.DocumentationBuilders.HTML;
+using Pickles.Parser;
+
+namespace Pickles.Test.Formatters
+{
+  [TestFixture]
+  public class HtmlScenarioFormatterTests : BaseFixture
+  {
+    private HtmlScenarioFormatter formatter;
+
+     [SetUp]
+    public void Setup()
+     {
+       this.formatter = new HtmlScenarioFormatter(
+         Kernel.Get<HtmlStepFormatter>(),
+         Kernel.Get<HtmlDescriptionFormatter>(),
+         Kernel.Get<HtmlImageResultFormatter>());
+     }
+
+     [Test]
+     public void Li_Element_Must_Not_Have_Id_Attribute()
+     {
+       var scenario = BuildMinimalScenario();
+
+       XElement li = formatter.Format(scenario, 1);
+
+       var idAttribute = li.Attribute("id");
+
+       Assert.IsNull(idAttribute);
+     }
+
+    private Scenario BuildMinimalScenario()
+    {
+      return new Scenario
+               {
+                 Description = "My Scenario Description",
+                 Steps = new List<Step>
+                           {
+                             new Step
+                               {
+                                 NativeKeyword = "Given",
+                                 Name = "My Step Name",
+                               }
+                           }
+               };
+    }
+  }
+}

--- a/src/Pickles/Pickles.Test/Formatters/HtmlScenarioOutlineFormatterTests.cs
+++ b/src/Pickles/Pickles.Test/Formatters/HtmlScenarioOutlineFormatterTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using NUnit.Framework;
+using Ninject;
+using Pickles.DocumentationBuilders.HTML;
+using Pickles.Parser;
+
+namespace Pickles.Test.Formatters
+{
+  [TestFixture]
+  public class HtmlScenarioOutlineFormatterTests : BaseFixture
+  {
+    private HtmlScenarioOutlineFormatter formatter;
+
+    [SetUp]
+    public void Setup()
+    {
+       formatter = new HtmlScenarioOutlineFormatter(Kernel.Get<HtmlStepFormatter>(), Kernel.Get<HtmlDescriptionFormatter>(), Kernel.Get<HtmlTableFormatter>(), Kernel.Get<HtmlImageResultFormatter>());
+    }
+
+    [Test]
+     public void Li_Element_Must_Not_Have_Id_Attribute()
+     {
+      var scenarioOutline = BuildMinimalScenarioOutline();
+
+      XElement li = formatter.Format(scenarioOutline, 1);
+
+       var idAttribute = li.Attribute("id");
+
+       Assert.IsNull(idAttribute);
+     }
+
+    private static ScenarioOutline BuildMinimalScenarioOutline()
+    {
+      var scenarioOutline = new ScenarioOutline
+                              {
+                                Description = "My Outline Description",
+                                Example = new Example
+                                            {
+                                              Description = "My Example Description",
+                                              TableArgument = new Table
+                                                                {
+                                                                  HeaderRow = new TableRow("Cell1"),
+                                                                  DataRows = new List<TableRow>(new[] { new TableRow("Value1") })
+                                                                },
+                                            },
+                                Steps = new List<Step>
+                                          {
+                                            new Step
+                                              {
+                                                NativeKeyword = "Given",
+                                                Name = "My Step Name",
+                                                TableArgument = new Table
+                                                                  {
+                                                                    HeaderRow = new TableRow("Cell1"),
+                                                                    DataRows = new List<TableRow>(new[] { new TableRow("Value1") })
+                                                                  },
+                                              }
+                                          }
+                              };
+      return scenarioOutline;
+    }
+  }
+}

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -159,6 +159,7 @@
     </Compile>
     <Compile Include="AssertExtensions.cs" />
     <Compile Include="BaseFixture.cs" />
+    <Compile Include="Formatters\HtmlScenarioOutlineFormatterTests.cs" />
     <Compile Include="WhenParsingMsTestResultsFile.cs" />
     <Compile Include="Formatters\JSON\when_creating_a_feature_with_meta_info.cs" />
     <Compile Include="Formatters\JSON\when_formatting_a_folder_structure_with_features.cs" />

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -159,6 +159,7 @@
     </Compile>
     <Compile Include="AssertExtensions.cs" />
     <Compile Include="BaseFixture.cs" />
+    <Compile Include="Formatters\HtmlScenarioFormatterTests.cs" />
     <Compile Include="Formatters\HtmlScenarioOutlineFormatterTests.cs" />
     <Compile Include="WhenParsingMsTestResultsFile.cs" />
     <Compile Include="Formatters\JSON\when_creating_a_feature_with_meta_info.cs" />

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlScenarioFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlScenarioFormatter.cs
@@ -49,7 +49,6 @@ namespace Pickles.DocumentationBuilders.HTML
         public XElement Format(Scenario scenario, int id)
         {
             return new XElement(xmlns + "li",
-                       new XAttribute("id", id),
                        new XAttribute("class", "scenario"),
                        this.htmlImageResultFormatter.Format(scenario),
                        new XElement(xmlns + "div",

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlScenarioOutlineFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlScenarioOutlineFormatter.cs
@@ -52,7 +52,6 @@ namespace Pickles.DocumentationBuilders.HTML
         public XElement Format(ScenarioOutline scenarioOutline, int id)
         {
             return new XElement(xmlns + "li",
-                       new XAttribute("id", id),
                        new XAttribute("class", "scenario"),
                        this.htmlImageResultFormatter.Format(scenarioOutline),
                        new XElement(xmlns + "div",


### PR DESCRIPTION
Hi,

I fixed the problem by removing the "id" attribute altogether. If and when an id attribute is needed, we should add one that does not start with a number :-)

Dirk

PS: one more fix coming up in the next days, about the xmlns attribute in the middle of the generated HTML.
