### PR TITLE
Xhtml namespace declaration

### DIFF
--- a/src/Pickles/Pickles.Test/NamespaceExtensionsTests.cs
+++ b/src/Pickles/Pickles.Test/NamespaceExtensionsTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Xml.Linq;
+using NUnit.Framework;
+using Pickles.Extensions;
+
+namespace Pickles.Test
+{
+  [TestFixture]
+  public class NamespaceExtensionsTests
+  {
+      private static readonly XNamespace newNamespace = XNamespace.Get("http://myNewNamespace/");
+
+      [Test]
+      public void MoveNamespace()
+      {
+        XElement tree1 = new XElement(
+          "Data",
+          new XElement(
+            "Child",
+            "content",
+            new XAttribute("MyAttr", "content")));
+
+        tree1.MoveToNamespace(newNamespace);
+
+        foreach (var node in tree1.DescendantsAndSelf())
+        {
+          node.AssertIsInNamespace(newNamespace.NamespaceName);
+        }
+      }
+  }
+}

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -161,6 +161,7 @@
     <Compile Include="BaseFixture.cs" />
     <Compile Include="Formatters\HtmlScenarioFormatterTests.cs" />
     <Compile Include="Formatters\HtmlScenarioOutlineFormatterTests.cs" />
+    <Compile Include="NamespaceExtensionsTests.cs" />
     <Compile Include="WhenParsingMsTestResultsFile.cs" />
     <Compile Include="Formatters\JSON\when_creating_a_feature_with_meta_info.cs" />
     <Compile Include="Formatters\JSON\when_formatting_a_folder_structure_with_features.cs" />

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlContentFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlContentFormatter.cs
@@ -41,7 +41,7 @@ namespace Pickles.DocumentationBuilders.HTML
 
         public XElement Format(IDirectoryTreeNode contentNode)
         {
-            var xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            var xmlns = HtmlNamespace.Xhtml;
 
             var featureItemNode = contentNode as FeatureDirectoryTreeNode;
             if (featureItemNode != null)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlDescriptionFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlDescriptionFormatter.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using System.Text;
 using MarkdownSharp;
 using System.Xml.Linq;
+using Pickles.Extensions;
 
 namespace Pickles.DocumentationBuilders.HTML
 {
@@ -31,17 +32,23 @@ namespace Pickles.DocumentationBuilders.HTML
     {
         private readonly Markdown markdown;
 
+        private readonly XNamespace xmlns;
+
         public HtmlDescriptionFormatter(Markdown markdown)
         {
             this.markdown = markdown;
+            this.xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
         }
 
         public XElement Format(string descriptionText)
         {
             if (String.IsNullOrEmpty(descriptionText)) return null;
 
-            var markdownResult = "<div class=\"description\" xmlns=\"http://www.w3.org/1999/xhtml\">" + markdown.Transform(descriptionText) + "</div>";
+            var markdownResult = "<div>" + markdown.Transform(descriptionText) + "</div>";
             var descriptionElements = XElement.Parse(markdownResult);
+            descriptionElements.SetAttributeValue("class", "description");
+
+            descriptionElements.MoveToNamespace(this.xmlns);
 
             return descriptionElements;
         }

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlDescriptionFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlDescriptionFormatter.cs
@@ -37,7 +37,7 @@ namespace Pickles.DocumentationBuilders.HTML
         public HtmlDescriptionFormatter(Markdown markdown)
         {
             this.markdown = markdown;
-            this.xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            this.xmlns = HtmlNamespace.Xhtml;
         }
 
         public XElement Format(string descriptionText)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlDocumentFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlDocumentFormatter.cs
@@ -60,7 +60,7 @@ namespace Pickles.DocumentationBuilders.HTML
 
         public XDocument Format(IDirectoryTreeNode featureNode, GeneralTree<IDirectoryTreeNode> features)
         {
-            var xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            var xmlns = HtmlNamespace.Xhtml;
             var featureNodeOutputPath = Path.Combine(this.configuration.OutputFolder.FullName, featureNode.RelativePathFromRoot);
             var featureNodeOutputUri = new Uri(featureNodeOutputPath);
 

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlFeatureFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlFeatureFormatter.cs
@@ -48,7 +48,7 @@ namespace Pickles.DocumentationBuilders.HTML
             this.htmlScenarioOutlineFormatter = htmlScenarioOutlineFormatter;
             this.htmlDescriptionFormatter = htmlDescriptionFormatter;
             this.htmlImageResultFormatter = htmlImageResultFormatter;
-            this.xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            this.xmlns = HtmlNamespace.Xhtml;
         }
 
         public XElement Format(Feature feature)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlFooterFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlFooterFormatter.cs
@@ -34,7 +34,7 @@ namespace Pickles.DocumentationBuilders.HTML
         public HtmlFooterFormatter(Configuration configuration)
         {
             this.configuration = configuration;
-            this.xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            this.xmlns = HtmlNamespace.Xhtml;
         }
 
         private XElement BuildVersionString()

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlHeaderFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlHeaderFormatter.cs
@@ -30,7 +30,7 @@ namespace Pickles.DocumentationBuilders.HTML
     {
         public XElement Format()
         {
-            var xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            var xmlns = HtmlNamespace.Xhtml;
             return new XElement(xmlns + "div",
                 new XAttribute("id", "top"));
         }

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlImageResultFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlImageResultFormatter.cs
@@ -40,7 +40,7 @@ namespace Pickles.DocumentationBuilders.HTML
             this.configuration = configuration;
             this.results = results;
             this.htmlResourceSet = htmlResourceSet;
-            this.xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            this.xmlns = HtmlNamespace.Xhtml;
         }
 
         private string BuildTitle(bool wasSuccessful)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlMarkdownFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlMarkdownFormatter.cs
@@ -37,7 +37,7 @@ namespace Pickles.DocumentationBuilders.HTML
         public HtmlMarkdownFormatter(Markdown markdown)
         {
             this.markdown = markdown;
-            this.xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            this.xmlns = HtmlNamespace.Xhtml;
         }
 
         public XElement Format(string text)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlMarkdownFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlMarkdownFormatter.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using MarkdownSharp;
+using Pickles.Extensions;
 
 namespace Pickles.DocumentationBuilders.HTML
 {
@@ -31,15 +32,23 @@ namespace Pickles.DocumentationBuilders.HTML
     {
         private readonly Markdown markdown;
 
+        private readonly XNamespace xmlns;
+
         public HtmlMarkdownFormatter(Markdown markdown)
         {
             this.markdown = markdown;
+            this.xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
         }
 
         public XElement Format(string text)
         {
             // HACK - we add the div around the markdown content because XElement requires a single root element from which to parse and Markdown.Transform() returns a series of elements
-            return XElement.Parse("<div id=\"markdown\" xmlns=\"http://www.w3.org/1999/xhtml\">" + this.markdown.Transform(text) + "</div>");
+            XElement xElement = XElement.Parse("<div>" + this.markdown.Transform(text) + "</div>");
+            xElement.SetAttributeValue("id", "markdown");
+
+            xElement.MoveToNamespace(this.xmlns);
+
+            return xElement;
         }
     }
 }

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlMultilineStringFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlMultilineStringFormatter.cs
@@ -32,7 +32,7 @@ namespace Pickles.DocumentationBuilders.HTML
 
         public HtmlMultilineStringFormatter()
         {
-            xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            xmlns = HtmlNamespace.Xhtml;
         }
 
         public XElement Format(string multilineText)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlNamespace.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlNamespace.cs
@@ -1,0 +1,12 @@
+﻿using System.Xml.Linq;
+
+namespace Pickles.DocumentationBuilders.HTML
+{
+  public static class HtmlNamespace
+  {
+    /// <summary>
+    /// An XNamespace instance for http://www.w3.org/1999/xhtml.
+    /// </summary>
+    public static readonly XNamespace Xhtml = XNamespace.Get("http://www.w3.org/1999/xhtml");
+  }
+}

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlScenarioFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlScenarioFormatter.cs
@@ -43,7 +43,7 @@ namespace Pickles.DocumentationBuilders.HTML
             this.htmlStepFormatter = htmlStepFormatter;
             this.htmlDescriptionFormatter = htmlDescriptionFormatter;
             this.htmlImageResultFormatter = htmlImageResultFormatter;
-            this.xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            this.xmlns = HtmlNamespace.Xhtml;
         }
 
         public XElement Format(Scenario scenario, int id)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlScenarioOutlineFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlScenarioOutlineFormatter.cs
@@ -46,7 +46,7 @@ namespace Pickles.DocumentationBuilders.HTML
             this.htmlDescriptionFormatter = htmlDescriptionFormatter;
             this.htmlTableFormatter = htmlTableFormatter;
             this.htmlImageResultFormatter = htmlImageResultFormatter;
-            this.xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            this.xmlns = HtmlNamespace.Xhtml;
         }
 
         public XElement Format(ScenarioOutline scenarioOutline, int id)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlStepFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlStepFormatter.cs
@@ -41,7 +41,7 @@ namespace Pickles.DocumentationBuilders.HTML
             this.htmlTableFormatter = htmlTableFormatter;
             this.htmlMultilineStringFormatter = htmlMultilineStringFormatter;
             this.languageServices = languageServices;
-            xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            xmlns = HtmlNamespace.Xhtml;
         }
 
         public XElement Format(Step step)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableFormatter.cs
@@ -33,7 +33,7 @@ namespace Pickles.DocumentationBuilders.HTML
 
         public HtmlTableFormatter()
         {
-            xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            xmlns = HtmlNamespace.Xhtml;
         }
 
         public XElement Format(Table table)

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableOfContentsFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableOfContentsFormatter.cs
@@ -66,7 +66,7 @@ namespace Pickles.DocumentationBuilders.HTML
 
         public XElement Format(Uri file, GeneralTree<IDirectoryTreeNode> features)
         {
-            var xmlns = XNamespace.Get("http://www.w3.org/1999/xhtml");
+            var xmlns = HtmlNamespace.Xhtml;
 
             return new XElement(xmlns + "div",
                        new XAttribute("id", "toc"),

--- a/src/Pickles/Pickles/Extensions/NamespaceExtensions.cs
+++ b/src/Pickles/Pickles/Extensions/NamespaceExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Pickles.Extensions
+{
+  /// <summary>
+  /// Extension Methods to work with namespaces.
+  /// </summary>
+  public static class NamespaceExtensions
+  {
+    /// <summary>
+    /// Moves <paramref name="element"/> into namespace <paramref name="newNamespace"/>.
+    /// </summary>
+    /// <param name="element">The element that will be moved into a new namespace.</param>
+    /// <param name="newNamespace">The new namespace for the element.</param>
+     public static void MoveToNamespace(this XElement element, XNamespace newNamespace)
+     {
+       foreach (XElement el in element.DescendantsAndSelf())
+       {
+         el.Name = newNamespace.GetName(el.Name.LocalName);
+       }
+     }
+  }
+}

--- a/src/Pickles/Pickles/Pickles.csproj
+++ b/src/Pickles/Pickles/Pickles.csproj
@@ -199,6 +199,7 @@
     <Compile Include="DocumentationBuilders\Word\WordTableFormatter.cs" />
     <Compile Include="DocumentationFormat.cs" />
     <Compile Include="Extensions\BodyExtensions.cs" />
+    <Compile Include="Extensions\NamespaceExtensions.cs" />
     <Compile Include="Extensions\PathExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="DirectoryCrawler\FeatureDirectoryTreeNode.cs" />

--- a/src/Pickles/Pickles/Pickles.csproj
+++ b/src/Pickles/Pickles/Pickles.csproj
@@ -174,6 +174,7 @@
     <Compile Include="DocumentationBuilders\HTML\HtmlImageResultFormatter.cs" />
     <Compile Include="DocumentationBuilders\HTML\HtmlMarkdownFormatter.cs" />
     <Compile Include="DocumentationBuilders\HTML\HtmlMultilineStringFormatter.cs" />
+    <Compile Include="DocumentationBuilders\HTML\HtmlNamespace.cs" />
     <Compile Include="DocumentationBuilders\HTML\HtmlResource.cs" />
     <Compile Include="DocumentationBuilders\HTML\HtmlResourceSet.cs" />
     <Compile Include="DocumentationBuilders\HTML\HtmlResourceWriter.cs" />


### PR DESCRIPTION
Hi,

I solved the issue with the xhtml namespace occurring within the html.  I had to try a few alternatives but I did find one that leaves the xhtml namespaces of the document intact and "only" makes the divs that enclose markdown content behave properly.

And I created a static declaration of an XNamespace element for the xhtml namespace so that the 
string http://www.w3.org/1999/xhtml isn't repeated so often.

Dirk
