### PR TITLE
Toning down the colors of the table of content.

### DIFF
--- a/src/Pickles/Pickles.Test/Formatters/HtmlTableOfContentsFormatterTests.cs
+++ b/src/Pickles/Pickles.Test/Formatters/HtmlTableOfContentsFormatterTests.cs
@@ -50,7 +50,7 @@ namespace Pickles.Test.Formatters
 
             var anchorInLI1 = li1.Elements().First();
             Assert.AreEqual(true, anchorInLI1.HasAttributes);
-            Assert.AreEqual("#", anchorInLI1.Attribute("href").Value);
+            Assert.AreEqual("current", anchorInLI1.Attribute("class").Value);
             Assert.AreEqual("This is an index written in Markdown", anchorInLI1.Value);
         }
 
@@ -80,6 +80,12 @@ namespace Pickles.Test.Formatters
             int numberOfLiChildren = childrenOfUl.Count(e => e.Name.LocalName == "li");
 
             Assert.AreEqual(numberOfChildren, numberOfLiChildren);
+        }
+
+        [Test]
+        public void TableOfContent_Must_Contain_One_Paragraph_With_Current_Class()
+        {
+            _toc.Descendants().Where(e => e.Name.LocalName == "p").Single(e => e.Attributes().Any(a => a.Name.LocalName == "class" && a.Value == "current"));
         }
     }
 }

--- a/src/Pickles/Pickles.Test/Formatters/HtmlTableOfContentsFormatterTests.cs
+++ b/src/Pickles/Pickles.Test/Formatters/HtmlTableOfContentsFormatterTests.cs
@@ -85,7 +85,7 @@ namespace Pickles.Test.Formatters
         [Test]
         public void TableOfContent_Must_Contain_One_Paragraph_With_Current_Class()
         {
-            _toc.Descendants().Where(e => e.Name.LocalName == "p").Single(e => e.Attributes().Any(a => a.Name.LocalName == "class" && a.Value == "current"));
+            _toc.Descendants().Where(e => e.Name.LocalName == "span").Single(e => e.Attributes().Any(a => a.Name.LocalName == "class" && a.Value == "current"));
         }
     }
 }

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableOfContentsFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableOfContentsFormatter.cs
@@ -47,7 +47,7 @@ namespace Pickles.DocumentationBuilders.HTML
                                 xmlns + "li",
                                 new XAttribute("class", "file"),
                                 new XElement(
-                                    xmlns + "p",
+                                    xmlns + "span",
                                     new XAttribute("class", "current"),
                                     childNode.Data.Name)));
                     }

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableOfContentsFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlTableOfContentsFormatter.cs
@@ -40,11 +40,28 @@ namespace Pickles.DocumentationBuilders.HTML
             {
                 if (childNode.Data.IsContent)
                 {
-                    ul.Add(
-                        new XElement(
-                            xmlns + "li",
-                            new XAttribute("class", "file"),
-                            new XElement(xmlns + "a", new XAttribute("href", childNode.Data.GetRelativeUriTo(file)), childNode.Data.Name)));
+                    if (childNode.Data.OriginalLocationUrl == file)
+                    {
+                        ul.Add(
+                            new XElement(
+                                xmlns + "li",
+                                new XAttribute("class", "file"),
+                                new XElement(
+                                    xmlns + "p",
+                                    new XAttribute("class", "current"),
+                                    childNode.Data.Name)));
+                    }
+                    else
+                    {
+                        ul.Add(
+                            new XElement(
+                                xmlns + "li",
+                                new XAttribute("class", "file"),
+                                new XElement(
+                                    xmlns + "a",
+                                    new XAttribute("href", childNode.Data.GetRelativeUriTo(file)),
+                                    childNode.Data.Name)));
+                    }
                 }
                 else
                 {

--- a/src/Pickles/Pickles/Resources/structure.css
+++ b/src/Pickles/Pickles/Resources/structure.css
@@ -49,14 +49,27 @@
   margin: 0 0 1em 0; 
 }
 
+
 #toc ul {
   margin: 0;
   padding: 0;
-  list-style-type: none;  }
+  list-style-type: none;
+}
+
   #toc ul li a {
-    text-decoration: none; }
+    text-decoration: none;
+      color: gray;
+  }
+
+  #toc .current
+  {
+      font-style: oblique;
+  }
+  
   #toc ul li a:hover {
-    text-decoration: underline; }
+    text-decoration: underline;
+  color: #000000;
+  }
     
 #toc .directory {
   padding: 5px 10px 6px;
@@ -66,7 +79,7 @@
   font-weight: bold;
 }
 #toc .file {
-  padding: 3px 10px 4px;
+  padding: 3px 10px 4px 20px;
   border-bottom: 1px solid #E8E8e8;
 }
 


### PR DESCRIPTION
- The links are now gray, and turn black on hover (like the << for collapsing/expanding the toc)
- the current item in the toc is no longer a link but a span, and is formatted to stand about from the rest a bit.
- I added a padding to the file items below a directory, to establish a hint of hierarchy.
