### PR TITLE
Log4Net 1.2.10

### DIFF
--- a/src/Pickles/Pickles.CommandLine/app.config
+++ b/src/Pickles/Pickles.CommandLine/app.config
@@ -36,5 +36,9 @@
         <bindingRedirect oldVersion="0.0.0.0-0.46.0.1" newVersion="0.46.0.1"/>
       </dependentAssembly>
     </assemblyBinding>
+    <dependentAssembly>
+      <assemblyIdentity name="Log4Net" publicKeyToken="b32731d11ce58905" culture="neutral" />
+      <bindingRedirect oldVersion="0.0.0.0-1.2.9.0" newVersion="1.2.10.0" />
+    </dependentAssembly>
   </runtime>
 </configuration>

--- a/src/Pickles/Pickles.NAnt/App.config
+++ b/src/Pickles/Pickles.NAnt/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Log4Net" publicKeyToken="b32731d11ce58905" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.9.0" newVersion="1.2.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Pickles/Pickles.NAnt/Pickles.NAnt.csproj
+++ b/src/Pickles/Pickles.NAnt/Pickles.NAnt.csproj
@@ -34,6 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="NAnt.Core">
       <HintPath>..\..\..\lib\nant\NAnt.Core.dll</HintPath>
     </Reference>
@@ -61,6 +64,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Pickles/Pickles.NAnt/packages.config
+++ b/src/Pickles/Pickles.NAnt/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="log4net" version="1.2.10" />
   <package id="MarkdownSharp" version="1.13.0.0" />
   <package id="Ninject" version="2.2.1.4" />
 </packages>


### PR DESCRIPTION
Adding assembly redirects for Log4Net to version 1.2.10 to Pickles.NAnt and Pickles.CommandLine - that should get rid of the compiler warning of Pickles.NAnt being unable to decide between 1.2.9 and 1.2.10.
