### PR TITLE
Fixed bug in PathExtensions.MakeRelativePath where trailing slash on directory was doubled up

### DIFF
--- a/src/Pickles/Pickles.Test/Extensions/PathExtensionsTests.cs
+++ b/src/Pickles/Pickles.Test/Extensions/PathExtensionsTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+using Pickles.Extensions;
+
+namespace Pickles.Test.Extensions
+{
+    [TestFixture]
+    class PathExtensionsTests
+    {
+        [Test]
+        public void Get_A_Relative_Path_When_Location_Is_Deeper_Than_Root()
+        {
+            // Arrange
+            string root = @"c:\test";
+            string location = @"c:\test\blah.feature";
+
+            string expected = @"test\blah.feature";
+            
+            // Act
+            string actual = PathExtensions.MakeRelativePath(root, location);
+
+            // Assert
+            Assert.AreEqual(actual, expected, string.Format("Expected {0} got {1}", expected, actual));
+        }
+
+        [Test]
+        public void Get_A_Relative_Path_When_Location_Is_Deeper_Than_Root_Even_When_Root_Contains_End_Slash()
+        {
+            string root = @"c:\test\";
+            string location = @"c:\test\blah.feature";
+            string expected = @"test\blah.feature";
+
+            string actual = PathExtensions.MakeRelativePath(root, location);
+
+            Assert.AreEqual(actual, expected, string.Format("Expected {0} got {1}", expected, actual));
+        }
+
+    }
+}

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -161,6 +161,7 @@
     <Compile Include="AssertExtensions.cs" />
     <Compile Include="BaseFixture.cs" />
     <Compile Include="DirectoryCrawlers\FolderDirectoryTreeNodeTests.cs" />
+    <Compile Include="Extensions\PathExtensionsTests.cs" />
     <Compile Include="Extensions\UriExtensionsTests.cs" />
     <Compile Include="Formatters\HtmlContentFormatterTests.cs" />
     <Compile Include="Formatters\HtmlScenarioFormatterTests.cs" />

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlImageResultFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlImageResultFormatter.cs
@@ -79,8 +79,8 @@ namespace Pickles.DocumentationBuilders.HTML
             if (configuration.HasTestResults)
             {
                 TestResult scenarioResult = this.results.GetFeatureResult(feature);
-                if (!scenarioResult.WasExecuted || !scenarioResult.WasSuccessful) return null;
-                return BuildImageElement(scenarioResult);
+
+                return scenarioResult.WasExecuted ? BuildImageElement(scenarioResult) : null;
             }
 
             return null;
@@ -91,8 +91,8 @@ namespace Pickles.DocumentationBuilders.HTML
             if (configuration.HasTestResults)
             {
                 TestResult scenarioResult = this.results.GetScenarioResult(scenario);
-                if (!scenarioResult.WasExecuted || !scenarioResult.WasSuccessful) return null;
-                return BuildImageElement(scenarioResult);
+                
+                return scenarioResult.WasExecuted ? BuildImageElement(scenarioResult) : null;
             }
 
             return null;
@@ -103,8 +103,8 @@ namespace Pickles.DocumentationBuilders.HTML
             if (configuration.HasTestResults)
             {
                 TestResult scenarioResult = this.results.GetScenarioOutlineResult(scenarioOutline);
-                if (!scenarioResult.WasExecuted || !scenarioResult.WasSuccessful) return null;
-                return BuildImageElement(scenarioResult);
+
+                return scenarioResult.WasExecuted ? BuildImageElement(scenarioResult) : null;
             }
 
             return null;

--- a/src/Pickles/Pickles/Extensions/PathExtensions.cs
+++ b/src/Pickles/Pickles/Extensions/PathExtensions.cs
@@ -33,10 +33,8 @@ namespace Pickles.Extensions
             if (string.IsNullOrEmpty(from)) throw new ArgumentNullException("from");
             if (string.IsNullOrEmpty(to)) throw new ArgumentNullException("to");
 
-            // Uri class treats paths that end in \ as directories, and without \ as files. 
-            // So if its a file then we need to append the \ to make the Uri class recognize it as a directory
-            string fromString = Directory.Exists(from) ? from + @"\" : from;
-            string toString = Directory.Exists(to) ? to + @"\" : to;
+            string fromString = AddTrailingSlashToDirectoriesForUriMethods(from);
+            string toString = AddTrailingSlashToDirectoriesForUriMethods(to);
 
             Uri fromUri = new Uri(fromString);
             Uri toUri = new Uri(toString);
@@ -45,6 +43,20 @@ namespace Pickles.Extensions
             string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
 
             return relativePath.Replace('/', Path.DirectorySeparatorChar);
+        }
+
+        private static string AddTrailingSlashToDirectoriesForUriMethods(string path)
+        {
+            // Uri class treats paths that end in \ as directories, and without \ as files. 
+            // So if its a file then we need to append the \ to make the Uri class recognize it as a directory
+            path = RemoveEndSlashSoWeDoNotHaveTwoIfThisIsADirectory(path);
+
+            return Directory.Exists(path) ? path + @"\" : path;
+        }
+
+        private static string RemoveEndSlashSoWeDoNotHaveTwoIfThisIsADirectory(string path)
+        {
+            return path.TrimEnd('\\');
         }
 
         public static string MakeRelativePath(FileSystemInfo from, FileSystemInfo to)

--- a/src/Pickles/Pickles/TestFrameworks/MsTestResults.cs
+++ b/src/Pickles/Pickles/TestFrameworks/MsTestResults.cs
@@ -121,7 +121,7 @@ namespace Pickles.TestFrameworks
                 let property = unitTest.Element(ns + "Properties").Element(ns + "Property")
                 let key = property.Element(ns + "Key")
                 let value = property.Element(ns + "Value")
-                where key.Value == "FeatureTitle" && value.Value == "Addition"
+                where key.Value == "FeatureTitle" && value.Value == scenarioOutline.Feature.Name
                 let description = unitTest.Element(ns + "Description")
                 where description.Value == scenarioOutline.Name
                 select new Guid(unitTest.Element(ns + "Execution").Attribute("id").Value);


### PR DESCRIPTION
Symptom: Trailing slash when specifying --feature-directory caused output directory to be file structure to be incorrect.  

Reason: PathExtensions.MakeRelativePath added in a trailing slash on a directory even if it had one which caused the Uri methods to interpret it as being 2 deep. 

Also would like to include:

Fixed 2 bugs. One in the HtmlImageResultsFormatter that did not show
a failure image when it should have.  I'm only suppressing the image
if it was not executed now.  The 2nd was a hard coded value for the
Addition feature that must have been left in there.  Verified this worked
using a test project.
