### PR TITLE
Fixing exception message being swallowed

### DIFF
--- a/src/Pickles/Pickles/FeatureParseException.cs
+++ b/src/Pickles/Pickles/FeatureParseException.cs
@@ -25,15 +25,15 @@ namespace Pickles
     [Serializable]
     public class FeatureParseException : Exception
     {
-        public FeatureParseException()
+        public FeatureParseException() : base()
         {
         }
 
-        public FeatureParseException(string msg)
+        public FeatureParseException(string msg) : base(msg)
         {
         }
 
-        public FeatureParseException(string msg, Exception e)
+        public FeatureParseException(string msg, Exception e) :base(msg,e)
         {
         }
     }


### PR DESCRIPTION
This fix an issue that we have when pickles fails to parse a file but the error msg is not propagated to the base class.
