### PR TITLE
Minor bug fixes for formatters

### DIFF
--- a/src/Pickles/Pickles.Test/DocumentationBuilders/Excel/WhenCreatingSheetNamesFromFeatures.cs
+++ b/src/Pickles/Pickles.Test/DocumentationBuilders/Excel/WhenCreatingSheetNamesFromFeatures.cs
@@ -81,5 +81,20 @@ namespace Pickles.Test.DocumentationBuilders
 
             name.ShouldEqual("THISISAREALLYREALLYLONGFEATUREN");
         }
+
+        [Test]
+        public void ThenItWillRemoveUnnecessaryAndInvalidCharacters()
+        {
+            var excelSheetNameGenerator = Kernel.Get<ExcelSheetNameGenerator>();
+            var feature = new Feature { Name = @"This Had invalid characters: :\/?*[]" };
+            
+            string name;
+            using (var wb = new XLWorkbook())
+            {
+                name = excelSheetNameGenerator.GenerateSheetName(wb, feature);
+            }
+
+            name.ShouldEqual("THISHASINVALIDCHARACTERS");
+        }
     }
 }

--- a/src/Pickles/Pickles/DocumentationBuilders/Excel/ExcelFeatureFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Excel/ExcelFeatureFormatter.cs
@@ -30,8 +30,7 @@ namespace Pickles.DocumentationBuilders.Excel
         private readonly ExcelScenarioOutlineFormatter excelScenarioOutlineFormatter;
         private readonly Configuration configuration;
         private readonly ITestResults testResults;
-        private uint nextId = 1;
-
+        
         public ExcelFeatureFormatter(ExcelScenarioFormatter excelScenarioFormatter,
                                      ExcelScenarioOutlineFormatter excelScenarioOutlineFormatter,
                                      Configuration configuration,

--- a/src/Pickles/Pickles/DocumentationBuilders/Excel/ExcelSheetNameGenerator.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Excel/ExcelSheetNameGenerator.cs
@@ -28,7 +28,7 @@ namespace Pickles.DocumentationBuilders.Excel
     {
         public string GenerateSheetName(XLWorkbook workbook, Feature feature)
         {
-            string name = feature.Name.Replace(" ", string.Empty).Replace("\t", string.Empty).ToUpperInvariant();
+            string name = RemoveUnnecessaryAndIllegalCharacters(feature).ToUpperInvariant();
             if (name.Length > 31) name = name.Substring(0, 31);
 
             // check if the workbook contains any sheets with this name
@@ -40,6 +40,20 @@ namespace Pickles.DocumentationBuilders.Excel
             }
 
             return name;
+        }
+
+        private static string RemoveUnnecessaryAndIllegalCharacters(Feature feature)
+        {
+            return feature.Name
+                .Replace(" ", string.Empty)
+                .Replace("\t", string.Empty)
+                .Replace(":", string.Empty)
+                .Replace(@"\", string.Empty)
+                .Replace("/", string.Empty)
+                .Replace("?", string.Empty)
+                .Replace("*", string.Empty)
+                .Replace("[", string.Empty)
+                .Replace("]", string.Empty);
         }
     }
 }

--- a/src/Pickles/Pickles/DocumentationBuilders/Excel/ExcelTableOfContentsFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Excel/ExcelTableOfContentsFormatter.cs
@@ -47,9 +47,7 @@ namespace Pickles.DocumentationBuilders.Excel
                 var featureChildNode = childNode.Data as FeatureDirectoryTreeNode;
                 if (featureChildNode != null)
                 {
-                    IXLWorksheet featureWorksheet =
-                        workbook.Worksheets.SingleOrDefault(
-                            sheet => sheet.Cell("A1").Value.ToString() == featureChildNode.Feature.Name);
+                    var featureWorksheet = FindFirstMatchingA1TitleUsingFeatureName(workbook, featureChildNode);
                     WriteFileCell(worksheet, ref row, column, featureWorksheet);
                 }
                 else if (!childNode.Data.IsContent)
@@ -58,6 +56,12 @@ namespace Pickles.DocumentationBuilders.Excel
                     BuildTableOfContents(workbook, worksheet, ref row, column + 1, childNode);
                 }
             }
+        }
+
+        private static IXLWorksheet FindFirstMatchingA1TitleUsingFeatureName(XLWorkbook workbook, FeatureDirectoryTreeNode featureChildNode)
+        {
+            return workbook.Worksheets.FirstOrDefault(
+                sheet => sheet.Cell("A1").Value.ToString() == featureChildNode.Feature.Name);
         }
 
         public void Format(XLWorkbook workbook, GeneralTree<IDirectoryTreeNode> features)

--- a/src/Pickles/Pickles/DocumentationBuilders/Word/WordScenarioOutlineFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Word/WordScenarioOutlineFormatter.cs
@@ -28,23 +28,24 @@ namespace Pickles.DocumentationBuilders.Word
     public class WordScenarioOutlineFormatter
     {
         private readonly Configuration configuration;
-        private readonly ITestResults nunitResults;
+        private readonly ITestResults testResults;
         private readonly WordStepFormatter wordStepFormatter;
         private readonly WordTableFormatter wordTableFormatter;
 
         public WordScenarioOutlineFormatter(WordStepFormatter wordStepFormatter, WordTableFormatter wordTableFormatter,
-                                            Configuration configuration, ITestResults nunitResults)
+                                            Configuration configuration, ITestResults testResults)
         {
             this.wordStepFormatter = wordStepFormatter;
             this.wordTableFormatter = wordTableFormatter;
             this.configuration = configuration;
+            this.testResults = testResults;
         }
 
         public void Format(Body body, ScenarioOutline scenarioOutline)
         {
             if (configuration.HasTestResults)
             {
-                TestResult testResult = nunitResults.GetScenarioOutlineResult(scenarioOutline);
+                TestResult testResult = testResults.GetScenarioOutlineResult(scenarioOutline);
                 if (testResult.WasExecuted && testResult.WasSuccessful)
                 {
                     body.GenerateParagraph("Passed", "Passed");


### PR DESCRIPTION
1. Added in the removal of invalid characters in excel name generator
2. Added in workaround in the excel TOC builder for when a scenario name
   is reused.  Return the first hit.
3. Fixed missed injected variable being set to global in work formatter.
