### PR TITLE
Minor bugfix in test

### DIFF
--- a/src/Pickles/Pickles.Test/DocumentationBuilders/Excel/WhenCreatingSheetNamesFromFeatures.cs
+++ b/src/Pickles/Pickles.Test/DocumentationBuilders/Excel/WhenCreatingSheetNamesFromFeatures.cs
@@ -94,7 +94,7 @@ namespace Pickles.Test.DocumentationBuilders
                 name = excelSheetNameGenerator.GenerateSheetName(wb, feature);
             }
 
-            name.ShouldEqual("THISHASINVALIDCHARACTERS");
+            name.ShouldEqual("THISHADINVALIDCHARACTERS");
         }
     }
 }


### PR DESCRIPTION
ThenItWillRemoveUnnecessaryAndInvalidCharacters test failed due to "This Had invalid characters: :\/?*[]" != THISHASINVALIDCHARACTERS
