### PR TITLE
Language parmeter exists but was never assigned to configuration

### DIFF
--- a/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
+++ b/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
@@ -90,6 +90,11 @@ namespace Pickles.PowerShell
             if (!string.IsNullOrEmpty(DocumentationFormat))
                 configuration.DocumentationFormat =
                     (DocumentationFormat) Enum.Parse(typeof (DocumentationFormat), DocumentationFormat, true);
+
+            if (!string.IsNullOrEmpty(Language))
+            {
+                configuration.Language = Language;
+             }
         }
     }
 }


### PR DESCRIPTION
Language parmeter exists but was never assigned to configuration. So now
PowerShell also supports language localization.
